### PR TITLE
Bump ansible to 2.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See `Supported Providers` section for more details.
 
 ## Tested with Ansible
 
-Tested with ansible-core >=2.14 releases.
+Tested with ansible-core >=2.15 releases.
 
 ## Installation
 

--- a/changelogs/fragments/bump_215.yaml
+++ b/changelogs/fragments/bump_215.yaml
@@ -1,0 +1,6 @@
+---
+release_summary: >
+  With this release, the minimum required version of `ansible-core` for this collection is `2.15.0`.
+  The last version known to be compatible with `ansible-core` versions below `2.15` is v3.0.1.
+major_changes:
+  - Bumping `requires_ansible` to `>=2.15.0`, since previous ansible-core versions are EoL now.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"


### PR DESCRIPTION
Bumps ansible to 2.15.0 as previous vrsion (2.14) is EoL now.